### PR TITLE
ODP:6361 | KAFKA-427: Bump ktlint version to 0.31.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,7 +219,7 @@ spotless {
     }
 
     kotlinGradle {
-        ktlint("0.30.0")
+        ktlint("0.31.0")
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()


### PR DESCRIPTION
This patch was tested locally.